### PR TITLE
Color confidence logic

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ from tornado.web import Application
 from speech_to_text.speech_to_text_annotator import SpeechToTextAnnotator
 from speech_to_text.microphone_access import PyaudioMicrophone
 from speech_to_text.speech_recognizer_software import GoogleCloudSpeechConverter
-from text_processing.color_annotator import ColorAnnotator
+from text_processing.color_annotator import TextProcessingAnnotator
 
 define('port', default=3000, help='port to listen on')
 
@@ -18,7 +18,7 @@ def main():
         ('/Speech', SpeechToTextAnnotator,
             {"audio_source": audio_source,
              "speech_processor": speech_converter}),
-        ('/color', ColorAnnotator)
+        ('/TextProcessing', TextProcessingAnnotator)
     ])
     http_server = HTTPServer(app)
     http_server.listen(options.port)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ tornado==5.1.1
 google-api-python-client==1.7.7
 oauth2client==4.1.2
 SpeechRecognition==3.8.1
+numpy==1.16.1

--- a/text_processing/color_annotator.py
+++ b/text_processing/color_annotator.py
@@ -30,14 +30,11 @@ class TextProcessingAnnotator(Annotator):
        
         to_analyze = sofa_string
         all_colors_in_text = []
-        for word in self.color_dict.keys:
+        for word in self.color_dict.keys():
             if is_word_in_str(word, to_analyze):
                 all_colors_in_text.append(word)
 
-        for color in all_colors_in_text:
-            print(color)
-
-        if len(color_to_find) == 0:
+        if len(all_colors_in_text) == 0:
             print("Did not find color in spoken text, cannot determine confidence rating based on text.")
             return
         
@@ -49,7 +46,7 @@ class TextProcessingAnnotator(Annotator):
             blue_hue = block['b_hue']
 
             block_rgb = [red_hue, green_hue, blue_hue]
-            analyzed_color_rgb = self.color_dict(color_to_find)
+            analyzed_color_rgb = self.color_dict[color_to_find]
             confidence = deltaE(block_rgb, analyzed_color_rgb)
             
             annotation = TextConfidenceAnnotation(block_id, confidence)

--- a/text_processing/color_annotator.py
+++ b/text_processing/color_annotator.py
@@ -1,38 +1,56 @@
 from base_annotator import Annotator, AnnotationType
+from text_processing.rgb2lab import deltaE
 
 import json
 from tornado.ioloop import IOLoop
 from tornado.web import Application
 
-class Color(AnnotationType):
-    ANNOTATION_UIMA_TYPE_NAME = "edu.rosehulman.aixprize.pipeline.types.Color"
+class TextConfidenceAnnotation(AnnotationType):
+    ANNOTATION_UIMA_TYPE_NAME = "edu.rosehulman.aixprize.pipeline.types.TextConfidence"
 
-    def __init__(self, color, start, end):
+    def __init__(self, id, confidence):
         self.name = self.ANNOTATION_UIMA_TYPE_NAME
-        self.color = color
-        self.begin = start
-        self.end = end
+        self.id = id
+        self.confidence = confidence
 
-def find_in_str(target, string, start=0):
+def is_word_in_str(target, string, start=0):
     idx = string.find(target)
-    if idx >= 0:
-        return [ Color(target, start + idx, start + idx + len(target) - 1) ] + \
-            find_in_str(target, string[idx + 1:], start=start + idx + 1)
-    return [ ]
+    return idx >= 0
 
-class ColorAnnotator(Annotator):
+class TextProcessingAnnotator(Annotator):
     def initialize(self):
         super().initialize()
-        with open("color_dictionary.json", encoding='utf-8') as f:
+        with open("./text_processing/color_dictionary.json", encoding='utf-8') as f:
             self.color_dict = json.load(f)
-        self.annotation_types.append(Color.ANNOTATION_UIMA_TYPE_NAME)
+        self.annotation_types.append(TextConfidenceAnnotation.ANNOTATION_UIMA_TYPE_NAME)
 
     def process(self, cas):
         sofa_string = cas['_views']['_InitialView']['SpokenText'][0]['text']
         blocks = cas['_views']['_InitialView']['DetectedBlock']
+       
         to_analyze = sofa_string
+        all_colors_in_text = []
         for word in self.color_dict.keys:
-            anns = find_in_str(word, to_analyze)
-            for a in anns:
-                print(a)
-                self.add_annotation(a)
+            if is_word_in_str(word, to_analyze):
+                all_colors_in_text.append(word)
+
+        for color in all_colors_in_text:
+            print(color)
+
+        if len(color_to_find) == 0:
+            print("Did not find color in spoken text, cannot determine confidence rating based on text.")
+            return
+        
+        color_to_find = all_colors_in_text[0]
+        for block in blocks:
+            block_id = block['id']
+            red_hue = block['r_hue']
+            green_hue = block['g_hue']
+            blue_hue = block['b_hue']
+
+            block_rgb = [red_hue, green_hue, blue_hue]
+            analyzed_color_rgb = self.color_dict(color_to_find)
+            confidence = deltaE(block_rgb, analyzed_color_rgb)
+            
+            annotation = TextConfidenceAnnotation(block_id, confidence)
+            self.add_annotation(annotation)


### PR DESCRIPTION
When we merged the previous PR relating to text processing and the resultant color confidence ratings (seen [here](https://github.com/RHIT-XPrize/annotator-server/pull/1)), we failed to catch the lack of logic to actually match blocks with the detected colors. This logic now exists and is integrated with the existing text processing code.