### PR TITLE
Feedback Unit

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from speech_to_text.microphone_access import PyaudioMicrophone
 from speech_to_text.speech_recognizer_software import GoogleCloudSpeechConverter
 from text_processing.color_annotator import TextProcessingAnnotator
 from confidence_aggregation.aggregate_confidence_annotator import AggregateConfidenceAnnotator
+from feedback.feedback_annotator import FeedbackAnnotator
 
 define('port', default=3000, help='port to listen on')
 
@@ -23,7 +24,8 @@ def main():
              "speech_processor": speech_converter}),
         ('/TextWithoutSpeech', DummyTextAnnotator),
         ('/TextProcessing', TextProcessingAnnotator),
-        ('/AggregateConfidence', AggregateConfidenceAnnotator)
+        ('/AggregateConfidence', AggregateConfidenceAnnotator),
+        ('/Feedback', FeedbackAnnotator)
     ])
     http_server = HTTPServer(app)
     http_server.listen(options.port)

--- a/confidence_aggregation/aggregate_confidence_annotator.py
+++ b/confidence_aggregation/aggregate_confidence_annotator.py
@@ -34,7 +34,7 @@ class AggregateConfidenceAnnotator(Annotator):
             normalized_text_conf = normalized_text_confidences[block_id]
 
             output_conf = normalized_pointing_conf * normalized_text_conf
-            annotation = AggregateConfidenceAnnotation(block_id, output_conf)
+            annotation = AggregateConfidenceAnnotation(block_id, output_conf, normalized_pointing_conf, normalized_text_conf)
             self.add_annotation(annotation)
 
     def normalize_data(self, data_to_normalize, data_bounds):
@@ -51,7 +51,9 @@ class AggregateConfidenceAnnotator(Annotator):
 class AggregateConfidenceAnnotation(AnnotationType):
     ANNOTATION_UIMA_TYPE_NAME = "edu.rosehulman.aixprize.pipeline.types.AggregateConfidence"
     
-    def __init__(self, id, confidence):
+    def __init__(self, id, confidence, normalized_pointing_conf, normalized_text_conf):
         self.name = self.ANNOTATION_UIMA_TYPE_NAME
         self.id = id
         self.confidence = confidence
+        self.normPointingConf = normalized_pointing_conf
+        self.normTextConf = normalized_text_conf

--- a/feedback/feedback_annotator.py
+++ b/feedback/feedback_annotator.py
@@ -1,0 +1,63 @@
+import json
+from base_annotator import Annotator, AnnotationType
+
+class FeedbackAnnotator(Annotator):
+    RUN_AGAIN_MESSAGE = "I had trouble determining which block you are referring to; please try me again!"
+    SUCCESS_MESSAGE = "I have found the block! I will try to pick it up!"
+    AMBIGUITY_TEMPLATE = "I struggled to tell the difference between %d other block(s) near the selected block. Try me again!"
+    AMBIGUITY_PERCENT_DIFF = 5
+
+
+    def initialize(self):
+        super().initialize()
+        self.annotation_types.append(FeedbackAnnotation.ANNOTATION_UIMA_TYPE_NAME)
+
+    def process(self, cas):
+        all_filtered_blocks = cas['_views']['_InitialView']['FilteredBlock']
+        selected_block_id = self.find_best_block_id(all_filtered_blocks)
+
+        all_detected_blocks = cas['_views']['_InitialView']['DetectedBlock']
+        agg_conf_scores = cas['_views']['_InitialView']['AggregateConfidence']
+        feedback_msg = self.determine_feedback_msg(selected_block_id, all_detected_blocks, agg_conf_scores)
+        print(feedback_msg)
+
+        annotation = FeedbackAnnotation(feedback_msg)
+        self.add_annotation(annotation)
+
+    def find_best_block_id(self, all_filtered_blocks):
+        best_block_id = -1
+        for curr_idx in range(0, len(all_filtered_blocks)):
+            block_id = all_filtered_blocks[curr_idx]['id']
+            is_best_block = all_filtered_blocks[curr_idx]['isSelectedBlock']
+
+            if is_best_block == 1:
+                best_block_id = block_id
+                return int(best_block_id)
+        return best_block_id
+
+    def determine_feedback_msg(self, selected_block_id, detected_blocks, agg_conf_scores):
+        if selected_block_id == -1:
+            return self.RUN_AGAIN_MESSAGE
+        
+
+        best_block_pointing_score = agg_conf_scores[selected_block_id]['normPointingConf']
+        num_ambiguous = 0
+        for curr_idx in range(0, len(detected_blocks)):
+            curr_block_scores = agg_conf_scores[curr_idx]
+            pointing_score = curr_block_scores['normPointingConf']
+
+            percent_diff = abs(best_block_pointing_score - pointing_score) / best_block_pointing_score * 100
+            if percent_diff <= self.AMBIGUITY_PERCENT_DIFF and curr_idx != best_block_pointing_score:
+                num_ambiguous = num_ambiguous + 1
+
+        if num_ambiguous > 0:
+            return self.AMBIGUITY_TEMPLATE % (num_ambiguous)
+            
+        return self.SUCCESS_MESSAGE
+
+class FeedbackAnnotation(AnnotationType):
+    ANNOTATION_UIMA_TYPE_NAME = "edu.rosehulman.aixprize.pipeline.types.Feedback"
+    
+    def __init__(self, message):
+        self.name = self.ANNOTATION_UIMA_TYPE_NAME
+        self.feedbackMsg = message

--- a/speech_to_text/microphone_access.py
+++ b/speech_to_text/microphone_access.py
@@ -15,9 +15,9 @@ class PyaudioMicrophone(MicrophoneProxy):
     def listen_for_snippet(self):
         with sr.Microphone() as source:
             print()
-            print("Adjusting for ambient noise...")
+            print("Hello! I am adjusting for ambient noise, please wait...")
             self.speech_recognizer.pause_threshold = self.PAUSE_THRESHOLD_SEC
             self.speech_recognizer.adjust_for_ambient_noise(source, duration=self.MAX_ADJUST_SEC) 
-            print("Give your command to the system!")
+            print("Please tell me your command!")
             audio = self.speech_recognizer.listen(source)
             return audio

--- a/speech_to_text/speech_recognizer_software.py
+++ b/speech_to_text/speech_recognizer_software.py
@@ -18,14 +18,14 @@ class GoogleCloudSpeechConverter(SpeechConverter):
         # Log errors to console if they occur
         try:
             processed_text = self.speech_recognizer.recognize_google_cloud(audio_snippet, credentials_json=credentials)
-            print("Google Cloud Speech thinks you said " + processed_text)
+            print("I think you said: " + processed_text)
             return processed_text
         except sr.UnknownValueError:
-            print("Google Cloud Speech could not understand audio")
+            print("My friend Google Cloud Speech could not understand audio")
             traceback.print_exc()
             return ""
         except sr.RequestError as e:
-            print("Could not request results from Google Cloud Speech service; {0}".format(e))
+            print("Could not request results from my friend, Google Cloud Speech service; {0}".format(e))
             traceback.print_exc()
             return ""
         

--- a/text_processing/color_annotator.py
+++ b/text_processing/color_annotator.py
@@ -52,7 +52,7 @@ class TextProcessingAnnotator(Annotator):
             scaled_rgb = [hue / max_hue_value * 255 for hue in block_rgb]
         
             analyzed_color_rgb = self.color_dict[color_to_find]
-            deltaValue = self.rgb_dist(scaled_rgb, analyzed_color_rgb)
+            deltaValue = deltaE(scaled_rgb, analyzed_color_rgb)
             confidence = 1 / deltaValue if deltaValue != 0 else 0
 
             annotation = TextConfidenceAnnotation(block_id, confidence)


### PR DESCRIPTION
Our ideal system included the ability to provide the user insight into the outcome of processing at the end of the pipeline. This is implemented by adding a python annotator to analyze confidence scores from previous processing steps and provide different messages back to the user based on the analyzed values. There are 3 forms of response:
1) Indicate success
2) Indicate failure (wrong JSON payload sent to this annotator)
3) Ambiguity detected. Thresholding of scores indicates there are other blocks that are too close to distinguish

This last point is where most of the pain emerged with this feature. Thresholding was never perfectly tuned, so it can be a bit high variance in terms of results. Looking to improve or move this to a configuration file at a later date.